### PR TITLE
Upgrade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: CI
+on:
+  push:
+jobs:
+  build:
+    # https://markkarpov.com/post/github-actions-for-haskell-ci.html#complete-example
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cabal: ["3.10"]
+        ghc: ["8.8.4", "8.10.5", "9.4.5"]
+    env:
+      CONFIG: "--enable-tests --enable-benchmarks"
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - uses: haskell/actions/setup@v2.4.0
+        # https://github.com/haskell/actions
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+      - run: cabal v2-update $CONFIG
+      - run: cabal v2-freeze $CONFIG
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+      - run: cabal v2-build $CONFIG
+      - run: cabal v2-test $CONFIG
+      - run: cabal v2-haddock $CONFIG
+      - run: cabal v2-sdist

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,34 @@
+name: Hackage Publish
+on:
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  #
+  # “When a workflow is configured to run on the workflow_dispatch event,
+  # you can run the workflow using the Actions tab on GitHub”
+  #
+  # “To trigger the workflow_dispatch event, your workflow must be in the
+  # default branch”
+  #
+  workflow_dispatch:
+jobs:
+  hackage-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - uses: haskell/actions/setup@v2.4.0
+        # https://github.com/haskell/actions
+        id: setup-haskell-cabal
+        with:
+          ghc-version: "9.4.5"
+          cabal-version: "3.10"
+      - run: cabal v2-haddock --builddir=dist-newstyle/docs --haddock-for-hackage
+      - run: cabal v2-sdist
+      - uses: haskell-actions/hackage-publish@v1.1
+        # https://github.com/haskell-actions/hackage-publish
+        with:
+          hackageToken: ${{ secrets.HACKAGE_AUTHTOKEN_001 }}
+          packagesPath: dist-newstyle/sdist
+          docsPath: dist-newstyle/docs
+          publish: true
+
+# cabal Support authentication tokens for uploading files
+# https://github.com/haskell/cabal/issues/6738

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Revision history for replace-megaparsec
 
+## 1.5.0.0 -- 2023-05-08
+
+Upgrade to GHC v9.4.4, text v2.0.1
+
+Text does not work with GHC v9.4.3
+
+Test
+* exitcode-stdio-1.0 instead of detailed-0.9
+* HSpec instead of Cabal Distribution.TestSuite
+
+Added megaparsec version bounds #36
+
 ## 1.4.5.0 -- 2022-04-14
 
 Minor documentation changes.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,9 +5,8 @@
 Update .cabal file to new version
 
 ```
-nix-shell -p cabal-install -p ghc
-git tag v0.0.0.0
+nix develop
 cabal haddock
+cabal test
 cabal sdist
-
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677063315,
+        "narHash": "sha256-qiB4ajTeAOVnVSAwCNEEkoybrAlA+cpeiBxLobHndE8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "988cc958c57ce4350ec248d2d53087777f9e1949",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+# https://github.com/jonascarpay/template-haskell/blob/master/flake.nix
+{
+  description = "replace-megaparsec";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = inputs:
+    let
+      overlay = final: prev: {
+        haskell = prev.haskell // {
+          packageOverrides = hfinal: hprev:
+            prev.haskell.packageOverrides hfinal hprev // {
+              replace-megaparsec = hfinal.callCabal2nix "replace-megaparsec" ./. { };
+              # https://github.com/ddssff/listlike/issues/23
+              ListLike = prev.haskell.lib.dontCheck hprev.ListLike;
+            };
+        };
+      };
+      perSystem = system:
+        let
+          pkgs = import inputs.nixpkgs { inherit system; overlays = [ overlay ]; };
+          # hspkgs = pkgs.haskellPackages;
+          hspkgs = pkgs.haskell.packages.ghc944;
+        in
+        {
+          devShell = hspkgs.shellFor {
+            withHoogle = true;
+            packages = p: [ p.replace-megaparsec ];
+            buildInputs = [
+              hspkgs.cabal-install
+              hspkgs.haskell-language-server
+              # hspkgs.hlint
+              # hspkgs.ormolu
+              # pkgs.bashInteractive
+            ];
+          };
+        };
+    in
+    { inherit overlay; } // inputs.flake-utils.lib.eachDefaultSystem perSystem;
+}

--- a/replace-megaparsec.cabal
+++ b/replace-megaparsec.cabal
@@ -1,5 +1,5 @@
 name:                replace-megaparsec
-version:             1.4.5.0
+version:             1.5.0.0
 cabal-version:       1.18
 synopsis:            Find, replace, and split string patterns with Megaparsec parsers (instead of regex)
 homepage:            https://github.com/jamesdbrock/replace-megaparsec
@@ -24,8 +24,8 @@ source-repository head
 
 library
   hs-source-dirs:      src
-  build-depends:       base >= 4.0 && < 5.0
-                     , megaparsec
+  build-depends:       base >= 4.0
+                     , megaparsec >= 7.0.0
                      , bytestring
                      , text
                      , parser-combinators >= 1.2.0
@@ -33,40 +33,17 @@ library
   exposed-modules:     Replace.Megaparsec
                      , Replace.Megaparsec.Internal.ByteString
                      , Replace.Megaparsec.Internal.Text
-  ghc-options:         -O2 -Wall
 
-test-suite test-string
-  type:                detailed-0.9
-  test-module:         TestString
+test-suite test
+  type:                exitcode-stdio-1.0
+  main-is:             Test.hs
   hs-source-dirs:      tests
+  other-modules:       TestString, TestByteString, TestText
   default-language:    Haskell2010
-  build-depends:       base >= 4.0 && < 5.0
+  build-depends:       base >= 4.0
                      , replace-megaparsec
-                     , megaparsec
-                     , Cabal
-  ghc-options:         -Wall
-
-test-suite test-text
-  type:                detailed-0.9
-  test-module:         TestText
-  hs-source-dirs:      tests
-  default-language:    Haskell2010
-  build-depends:       base >= 4.0 && < 5.0
-                     , replace-megaparsec
-                     , megaparsec
-                     , Cabal
+                     , megaparsec >= 7.0.0
+                     , hspec
                      , text
-  ghc-options:         -Wall
-
-test-suite test-bytestring
-  type:                detailed-0.9
-  test-module:         TestByteString
-  hs-source-dirs:      tests
-  default-language:    Haskell2010
-  build-depends:       base >= 4.0 && < 5.0
-                     , replace-megaparsec
-                     , megaparsec
-                     , Cabal
                      , bytestring
-  ghc-options:         -Wall
-
+  ghc-options:         -Wall -debug

--- a/src/Replace/Megaparsec.hs
+++ b/src/Replace/Megaparsec.hs
@@ -88,7 +88,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Replace.Megaparsec
   (

--- a/src/Replace/Megaparsec/Internal/ByteString.hs
+++ b/src/Replace/Megaparsec/Internal/ByteString.hs
@@ -14,6 +14,7 @@
 
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Replace.Megaparsec.Internal.ByteString
   (

--- a/src/Replace/Megaparsec/Internal/Text.hs
+++ b/src/Replace/Megaparsec/Internal/Text.hs
@@ -14,6 +14,7 @@
 
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Replace.Megaparsec.Internal.Text
   (

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Main ( main ) where
+
+import Test.Hspec
+import TestString
+import TestByteString
+import TestText
+
+main :: IO ()
+main = hspec do
+  TestString.tests
+  TestByteString.tests
+  TestText.tests

--- a/tests/TestByteString.hs
+++ b/tests/TestByteString.hs
@@ -2,10 +2,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE BlockArguments #-}
 
 module TestByteString ( tests ) where
 
-import Distribution.TestSuite as TestSuite
 import Replace.Megaparsec
 import Text.Megaparsec
 import Text.Megaparsec.Byte
@@ -14,103 +14,71 @@ import Data.Void
 import qualified Data.ByteString as B
 import Data.ByteString.Internal (c2w)
 import GHC.Word
+import Test.Hspec (describe, shouldBe, it, SpecWith)
 
 type Parser = Parsec Void B.ByteString
 
 findAllCap' :: MonadParsec e s m => m a -> m [Either (Tokens s) (Tokens s, a)]
 findAllCap' sep = sepCap (match sep)
 
-tests :: IO [Test]
-tests = return
-    [ Test $ runParserTest "findAll upperChar"
+tests :: SpecWith ()
+tests = describe "input ByteString" do
+    runParserTest "findAll upperChar"
         (findAllCap' (upperChar :: Parser Word8))
         ("aBcD" :: B.ByteString)
         [Left "a", Right ("B", c2w 'B'), Left "c", Right ("D", c2w 'D')]
     -- check that sepCap can progress even when parser consumes nothing
     -- and succeeds.
-    , Test $ runParserTest "zero-consumption parser"
+    runParserTest "zero-consumption parser"
         (sepCap (many (upperChar :: Parser Word8)))
         ("aBcD" :: B.ByteString)
         [Left "a", Right [c2w 'B'], Left "c", Right [c2w 'D']]
-    , Test $ runParserTest "scinum"
+    runParserTest "scinum"
         (sepCap scinum)
-        ("1E3")
-        ([Right (1,3)])
-    , Test $ runParserTest "getOffset"
+        "1E3"
+        [Right (1,3)]
+    runParserTest "getOffset"
         (sepCap offsetA)
-        ("xxAxx")
-        ([Left "xx", Right 2, Left "xx"])
-    , Test $ runParserTest "monad fail"
+        "xxAxx"
+        [Left "xx", Right 2, Left "xx"]
+    runParserTest "monad fail"
         (sepCap (fail "" :: Parser ()))
-        ("xxx")
-        ([Left "xxx"])
+        "xxx"
+        [Left "xxx"]
 #if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
-    , Test $ runParserTest "read fail"
+    runParserTest "read fail"
         (sepCap (return (read "a" :: Int) :: Parser Int))
-        ("a")
-        ([Left "a"])
+        "a"
+        [Left "a"]
 #endif
-    , Test $ runParserTest "empty input" (sepCap (fail "" :: Parser ())) "" []
-    , Test $ streamEditTest "x to o"
+    runParserTest "empty input" (sepCap (fail "" :: Parser ())) "" []
+    streamEditTest "x to o"
         (string "x" :: Parser B.ByteString) (const "o")
         "x x x" "o o o"
-    , Test $ streamEditTest "x to o inner"
+    streamEditTest "x to o inner"
         (string "x" :: Parser B.ByteString) (const "o")
         " x x x " " o o o "
-    , Test $ streamEditTest "ordering"
+    streamEditTest "ordering"
         (string "456" :: Parser B.ByteString) (const "ABC")
         "123456789" "123ABC789"
-    , Test $ streamEditTest "empty input" (match (fail "" :: Parser ())) (fst) "" ""
-    , Test $ breakCapTest "basic" (upperChar :: Parser Word8) "aAa" (Just ("a", c2w 'A', "a"))
-    , Test $ breakCapTest "first" (upperChar :: Parser Word8) "Aa" (Just ("", c2w 'A', "a"))
-    , Test $ breakCapTest "last" (upperChar :: Parser Word8) "aA" (Just ("a", c2w 'A', ""))
-    , Test $ breakCapTest "fail" (upperChar :: Parser Word8) "aaa" Nothing
-    , Test $ breakCapTest "match" (match (upperChar :: Parser Word8)) "aAa" (Just ("a", ("A",c2w 'A'), "a"))
-    , Test $ breakCapTest "zero-width" (lookAhead (upperChar :: Parser Word8)) "aAa" (Just ("a", c2w 'A', "Aa"))
-    , Test $ breakCapTest "empty input" (upperChar :: Parser Word8) "" Nothing
-    , Test $ breakCapTest "empty input zero-width" (return () :: Parser ()) "" (Just ("", (), ""))
-    ]
+    streamEditTest "empty input" (match (fail "" :: Parser ())) fst "" ""
+    breakCapTest "basic" (upperChar :: Parser Word8) "aAa" (Just ("a", c2w 'A', "a"))
+    breakCapTest "first" (upperChar :: Parser Word8) "Aa" (Just ("", c2w 'A', "a"))
+    breakCapTest "last" (upperChar :: Parser Word8) "aA" (Just ("a", c2w 'A', ""))
+    breakCapTest "fail" (upperChar :: Parser Word8) "aaa" Nothing
+    breakCapTest "match" (match (upperChar :: Parser Word8)) "aAa" (Just ("a", ("A",c2w 'A'), "a"))
+    breakCapTest "zero-width" (lookAhead (upperChar :: Parser Word8)) "aAa" (Just ("a", c2w 'A', "Aa"))
+    breakCapTest "empty input" (upperChar :: Parser Word8) "" Nothing
+    breakCapTest "empty input zero-width" (return () :: Parser ()) "" (Just ("", (), ""))
   where
-    runParserTest nam p input expected = TestInstance
-            { run = do
-                case runParser p "" input of
-                    Left e -> return (Finished $ Fail $ show e)
-                    Right output ->
-                        if (output == expected)
-                            then return (Finished Pass)
-                            else return (Finished $ Fail
-                                        $ "got " <> show output <> " expected " <> show expected)
-            , name = nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    runParserTest nam p input expected = it nam $ shouldBe
+        (runParser p "" input) (Right expected)
 
-    streamEditTest nam sep editor input expected = TestInstance
-            { run = do
-                let output = streamEdit sep editor input
-                if (output == expected)
-                    then return (Finished Pass)
-                    else return (Finished $ TestSuite.Fail
-                                $ "got " <> show output <> " expected " <> show expected)
-            , name = "streamEdit " ++ nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    streamEditTest nam sep editor input expected = it nam $ shouldBe
+        (streamEdit sep editor input) expected
 
-    breakCapTest nam sep input expected = TestInstance
-            { run = do
-                let output = breakCap sep input
-                if (output == expected)
-                    then return (Finished Pass)
-                    else return (Finished $ TestSuite.Fail
-                                $ "got " <> show output <> " expected " <> show expected)
-            , name = "breakCap " ++ nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    breakCapTest nam sep input expected = it nam $ shouldBe
+        (breakCap sep input) expected
 
     scinum :: Parser (Double, Integer)
     scinum = do

--- a/tests/TestString.hs
+++ b/tests/TestString.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE BlockArguments #-}
 
 module TestString ( tests ) where
 
-import Distribution.TestSuite
-import Distribution.TestSuite as TestSuite
 import Replace.Megaparsec
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Data.Void
 import Data.Bifunctor (second)
+import Test.Hspec (describe, shouldBe, it, SpecWith)
 
 type Parser = Parsec Void String
 
@@ -20,101 +20,68 @@ findAllCap' sep = sepCap (match sep)
 findAll' :: MonadParsec e s f => f b -> f [Either (Tokens s) (Tokens s)]
 findAll' sep = (fmap.fmap) (second fst) $ sepCap (match sep)
 
-tests :: IO [Test]
-tests = return
-    [ Test $ runParserTest "findAll upperChar"
+tests :: SpecWith ()
+tests = describe "input String" do
+    runParserTest "findAll upperChar"
         (findAllCap' (upperChar :: Parser Char))
         ("aBcD" :: String)
         [Left "a", Right ("B", 'B'), Left "c", Right ("D", 'D')]
     -- check that sepCap can progress even when parser consumes nothing
     -- and succeeds.
-    , Test $ runParserTest "zero-consumption parser"
+    runParserTest "zero-consumption parser"
         (sepCap (many (upperChar :: Parser Char)))
         ("aBcD" :: String)
         [Left "a", Right "B", Left "c", Right "D"]
-    , Test $ runParserTest "scinum"
+    runParserTest "scinum"
         (sepCap scinum)
-        ("1E3")
-        ([Right (1,3)])
-    , Test $ runParserTest "getOffset"
+        "1E3"
+        [Right (1,3)]
+    runParserTest "getOffset"
         (sepCap offsetA)
-        ("xxAxx")
-        ([Left "xx", Right 2, Left "xx"])
-    , Test $ runParserTest "monad fail"
+        "xxAxx"
+        [Left "xx", Right 2, Left "xx"]
+    runParserTest "monad fail"
         (sepCap (fail "" :: Parser ()))
-        ("xxx")
-        ([Left "xxx"])
+        "xxx"
+        [Left "xxx"]
 #if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
-    , Test $ runParserTest "read fail"
+    runParserTest "read fail"
         (sepCap (return (read "a" :: Int) :: Parser Int))
         ("a")
         ([Left "a"])
 #endif
-    , Test $ runParserTest "findAll astral"
-        (findAll' ((takeWhileP Nothing (=='𝅘𝅥𝅯') :: Parser String)))
-        ("𝄞𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥")
+    runParserTest "findAll astral"
+        (findAll' (takeWhileP Nothing (=='𝅘𝅥𝅯') :: Parser String))
+        "𝄞𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥"
         [Left "𝄞𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥", Right "𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯", Left "𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥"]
-    , Test $ runParserTest "empty input" (sepCap (fail "" :: Parser ())) "" []
-    , Test $ streamEditTest "x to o"
+    runParserTest "empty input" (sepCap (fail "" :: Parser ())) "" []
+    streamEditTest "x to o"
         (string "x" :: Parser String) (const "o")
         "x x x" "o o o"
-    , Test $ streamEditTest "x to o inner"
+    streamEditTest "x to o inner"
         (string "x" :: Parser String) (const "o")
         " x x x " " o o o "
-    , Test $ streamEditTest "ordering"
+    streamEditTest "ordering"
         (string "456" :: Parser String) (const "ABC")
         "123456789" "123ABC789"
-    , Test $ streamEditTest "empty input" (match (fail "" :: Parser ())) (fst) "" ""
-    , Test $ breakCapTest "basic" (upperChar :: Parser Char) "aAa" (Just ("a", 'A', "a"))
-    , Test $ breakCapTest "first" (upperChar :: Parser Char) "Aa" (Just ("", 'A', "a"))
-    , Test $ breakCapTest "last" (upperChar :: Parser Char) "aA" (Just ("a", 'A', ""))
-    , Test $ breakCapTest "fail" (upperChar :: Parser Char) "aaa" Nothing
-    , Test $ breakCapTest "match" (match (upperChar :: Parser Char)) "aAa" (Just ("a", ("A",'A'), "a"))
-    , Test $ breakCapTest "zero-width" (lookAhead (upperChar :: Parser Char)) "aAa" (Just ("a", 'A', "Aa"))
-    , Test $ breakCapTest "empty input" (upperChar :: Parser Char) "" Nothing
-    , Test $ breakCapTest "empty input zero-width" (return () :: Parser ()) "" (Just ("", (), ""))
-    ]
+    streamEditTest "empty input" (match (fail "" :: Parser ())) fst "" ""
+    breakCapTest "basic" (upperChar :: Parser Char) "aAa" (Just ("a", 'A', "a"))
+    breakCapTest "first" (upperChar :: Parser Char) "Aa" (Just ("", 'A', "a"))
+    breakCapTest "last" (upperChar :: Parser Char) "aA" (Just ("a", 'A', ""))
+    breakCapTest "fail" (upperChar :: Parser Char) "aaa" Nothing
+    breakCapTest "match" (match (upperChar :: Parser Char)) "aAa" (Just ("a", ("A",'A'), "a"))
+    breakCapTest "zero-width" (lookAhead (upperChar :: Parser Char)) "aAa" (Just ("a", 'A', "Aa"))
+    breakCapTest "empty input" (upperChar :: Parser Char) "" Nothing
+    breakCapTest "empty input zero-width" (return () :: Parser ()) "" (Just ("", (), ""))
   where
-    runParserTest nam p input expected = TestInstance
-            { run = do
-                case runParser p "" input of
-                    Left e -> return (Finished $ Fail $ show e)
-                    Right output ->
-                        if (output == expected)
-                            then return (Finished Pass)
-                            else return (Finished $ Fail
-                                        $ "got " <> show output <> " expected " <> show expected)
-            , name = nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    runParserTest nam p input expected = it nam $ shouldBe
+        (runParser p "" input) (Right expected)
 
-    streamEditTest nam sep editor input expected = TestInstance
-            { run = do
-                let output = streamEdit sep editor input
-                if (output == expected)
-                    then return (Finished Pass)
-                    else return (Finished $ TestSuite.Fail
-                                $ "got " <> show output <> " expected " <> show expected)
-            , name = "streamEdit " ++ nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    streamEditTest nam sep editor input expected = it nam $ shouldBe
+        (streamEdit sep editor input) expected
 
-    breakCapTest nam sep input expected = TestInstance
-            { run = do
-                let output = breakCap sep input
-                if (output == expected)
-                    then return (Finished Pass)
-                    else return (Finished $ TestSuite.Fail
-                                $ "got " <> show output <> " expected " <> show expected)
-            , name = "breakCap " ++ nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    breakCapTest nam sep input expected = it nam $ shouldBe
+        (breakCap sep input) expected
 
     scinum :: Parser (Double, Integer)
     scinum = do
@@ -122,7 +89,6 @@ tests = return
         _ <- chunk "E"
         e <- some digitChar
         return (read m, read e)
-
 
     offsetA :: Parser Int
     offsetA = getOffset <* chunk "A"

--- a/tests/TestText.hs
+++ b/tests/TestText.hs
@@ -2,17 +2,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE BlockArguments #-}
 
 module TestText ( tests ) where
 
-import Distribution.TestSuite
-import Distribution.TestSuite as TestSuite
 import Replace.Megaparsec
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Data.Void
 import qualified Data.Text as T
 import Data.Bifunctor (second)
+import Test.Hspec (describe, shouldBe, it, SpecWith)
 
 type Parser = Parsec Void T.Text
 
@@ -22,118 +22,75 @@ findAllCap' sep = sepCap (match sep)
 findAll' :: MonadParsec e s f => f b -> f [Either (Tokens s) (Tokens s)]
 findAll' sep = (fmap.fmap) (second fst) $ sepCap (match sep)
 
-tests :: IO [Test]
-tests = return
-    [ Test $ runParserTest "findAll upperChar"
+tests :: SpecWith ()
+tests = describe "input Text" do
+    runParserTest "findAll upperChar"
         (findAllCap' (upperChar :: Parser Char))
         ("aBcD" :: T.Text)
         [Left "a", Right ("B", 'B'), Left "c", Right ("D", 'D')]
     -- check that sepCap can progress even when parser consumes nothing
     -- and succeeds.
-    , Test $ runParserTest "zero-consumption parser"
+    runParserTest "zero-consumption parser"
         (sepCap (many (upperChar :: Parser Char)))
         ("aBcD" :: T.Text)
         [Left "a", Right "B", Left "c", Right "D"]
-    , Test $ runParserTest "scinum"
+    runParserTest "scinum"
         (sepCap scinum)
         ("1E3")
         ([Right (1,3)])
-    , Test $ runParserTest "getOffset"
+    runParserTest "getOffset"
         (sepCap offsetA)
         ("xxAxx")
         ([Left "xx", Right 2, Left "xx"])
-    , Test $ runParserTest "monad fail"
+    runParserTest "monad fail"
         (sepCap (fail "" :: Parser ()))
         ("xxx")
         ([Left "xxx"])
 #if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
-    , Test $ runParserTest "read fail"
+    runParserTest "read fail"
         (sepCap (return (read "a" :: Int) :: Parser Int))
         ("a")
         ([Left "a"])
 #endif
-    , Test $ runParserTest "findAll astral"
-        (findAll' ((takeWhileP Nothing (=='𝅘𝅥𝅯') :: Parser T.Text)))
+    runParserTest "findAll astral"
+        (findAll' (takeWhileP Nothing (=='𝅘𝅥𝅯') :: Parser T.Text))
         ("𝄞𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥" :: T.Text)
         [Left "𝄞𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥", Right "𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯𝅘𝅥𝅯", Left "𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥"]
-    , Test $ runParserTest "empty input" (sepCap (fail "" :: Parser ())) "" []
-    , Test $ streamEditTest "x to o"
+    runParserTest "empty input" (sepCap (fail "" :: Parser ())) "" []
+    streamEditTest "x to o"
         (string "x" :: Parser T.Text) (const "o")
         "x x x" "o o o"
-    , Test $ streamEditTest "x to o inner"
+    streamEditTest "x to o inner"
         (string "x" :: Parser T.Text) (const "o")
         " x x x " " o o o "
-    , Test $ streamEditTest "ordering"
+    streamEditTest "ordering"
         (string "456" :: Parser T.Text) (const "ABC")
         "123456789" "123ABC789"
-    , Test $ streamEditTest "empty input" (match (fail "" :: Parser ())) (fst) "" ""
-    , Test $ breakCapTest "basic" (upperChar :: Parser Char) "aAa" (Just ("a", 'A', "a"))
-    , Test $ breakCapTest "first" (upperChar :: Parser Char) "Aa" (Just ("", 'A', "a"))
-    , Test $ breakCapTest "last" (upperChar :: Parser Char) "aA" (Just ("a", 'A', ""))
-    , Test $ breakCapTest "fail" (upperChar :: Parser Char) "aaa" Nothing
-    , Test $ breakCapTest "match" (match (upperChar :: Parser Char)) "aAa" (Just ("a", ("A",'A'), "a"))
-    , Test $ breakCapTest "zero-width" (lookAhead (upperChar :: Parser Char)) "aAa" (Just ("a", 'A', "Aa"))
-    , Test $ breakCapTest "empty input" (upperChar :: Parser Char) "" Nothing
-    , Test $ breakCapTest "empty input zero-width" (return () :: Parser ()) "" (Just ("", (), ""))
+    streamEditTest "empty input" (match (fail "" :: Parser ())) fst "" ""
+    breakCapTest "basic" (upperChar :: Parser Char) "aAa" (Just ("a", 'A', "a"))
+    breakCapTest "first" (upperChar :: Parser Char) "Aa" (Just ("", 'A', "a"))
+    breakCapTest "last" (upperChar :: Parser Char) "aA" (Just ("a", 'A', ""))
+    breakCapTest "fail" (upperChar :: Parser Char) "aaa" Nothing
+    breakCapTest "match" (match (upperChar :: Parser Char)) "aAa" (Just ("a", ("A",'A'), "a"))
+    breakCapTest "zero-width" (lookAhead (upperChar :: Parser Char)) "aAa" (Just ("a", 'A', "Aa"))
+    breakCapTest "empty input" (upperChar :: Parser Char) "" Nothing
+    breakCapTest "empty input zero-width" (return () :: Parser ()) "" (Just ("", (), ""))
     -- I was unable to write a failing test for
     -- https://github.com/jamesdbrock/replace-megaparsec/issues/33
     -- but adding this "sep backtrack" test anyway
-    , Test $ splitCapTest "sep backtrack" (match $ between (string "{{") (string "}}") (T.pack <$> many (alphaNumChar <|> spaceChar) :: Parser T.Text)) "{{foo.}}" [Left "{{foo.}}"]
-    ]
+    splitCapTest "sep backtrack" (match $ between (string "{{") (string "}}") (T.pack <$> many (alphaNumChar <|> spaceChar) :: Parser T.Text)) "{{foo.}}" [Left "{{foo.}}"]
   where
-    runParserTest nam p input expected = TestInstance
-            { run = do
-                case runParser p "" input of
-                    Left e -> return (Finished $ Fail $ show e)
-                    Right output ->
-                        if (output == expected)
-                            then return (Finished Pass)
-                            else return (Finished $ Fail
-                                        $ "got " <> show output <> " expected " <> show expected)
-            , name = nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    runParserTest nam p input expected = it nam $ shouldBe
+        (runParser p "" input) (Right expected)
 
-    streamEditTest nam sep editor input expected = TestInstance
-            { run = do
-                let output = streamEdit sep editor input
-                if (output == expected)
-                    then return (Finished Pass)
-                    else return (Finished $ TestSuite.Fail
-                                $ "got " <> show output <> " expected " <> show expected)
-            , name = "streamEdit " ++ nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    streamEditTest nam sep editor input expected = it nam $ shouldBe
+        (streamEdit sep editor input) expected
 
-    breakCapTest nam sep input expected = TestInstance
-            { run = do
-                let output = breakCap sep input
-                if (output == expected)
-                    then return (Finished Pass)
-                    else return (Finished $ TestSuite.Fail
-                                $ "got " <> show output <> " expected " <> show expected)
-            , name = "breakCap " ++ nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    breakCapTest nam sep input expected = it nam $ shouldBe
+        (breakCap sep input) expected
 
-    splitCapTest nam sep input expected = TestInstance
-            { run = do
-                let output = splitCap sep input
-                if (output == expected)
-                    then return (Finished Pass)
-                    else return (Finished $ TestSuite.Fail
-                                $ "got " <> show output <> " expected " <> show expected)
-            , name = "splitCap " ++ nam
-            , tags = []
-            , options = []
-            , setOption = \_ _ -> Left "no options supported"
-            }
+    splitCapTest nam sep input expected = it nam $ shouldBe
+        (splitCap sep input) expected
 
     scinum :: Parser (Double, Integer)
     scinum = do


### PR DESCRIPTION
Upgrade to GHC v9.4.4, text v2.0.1

Text does not work with GHC v9.4.3, see https://github.com/jamesdbrock/replace-megaparsec/issues/38

Test with exitcode-stdio-1.0 instead of detailed-0.9 Test with HSpec instead of Cabal Distribution.TestSuite

`flake.nix` for `nix develop`

https://github.com/jonascarpay/template-haskell/blob/master/flake.nix